### PR TITLE
fix: correct area argument to get_pois

### DIFF
--- a/api/views/isochrones.py
+++ b/api/views/isochrones.py
@@ -85,7 +85,7 @@ async def get_pois(
         features = await pois_service.get_pois(
             bbox=data.bbox,
             categories=data.categories,
-            source=data.source,
+            area=data.source,
             cached=data.cached
         )
         return features


### PR DESCRIPTION
The `get_pois` function was incorrectly called with `source=data.source`, which should have been `area=data.source`.